### PR TITLE
#109 - Return element path even if the parent is outdated

### DIFF
--- a/src/main/java/de/dataelementhub/model/handler/element/ElementPathHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/ElementPathHandler.java
@@ -60,8 +60,7 @@ public class ElementPathHandler {
         continue;
       }
       List<ScopedIdentifier> parentScopedIdentifiers = getParentScopedIdentifiers(ctx,
-          partialPath.get(0)).stream().filter(p ->
-          p.getStatus() != Status.OUTDATED).collect(Collectors.toList());
+          partialPath.get(0));
       partialPaths.remove(partialPath);
       if (parentScopedIdentifiers.size() > 0) {
         for (ScopedIdentifier parentScopedIdentifier : parentScopedIdentifiers) {


### PR DESCRIPTION
**What's in the PR**
* Do not ignore element path if the parent is outdated
* close #109 

**How to test manually**
1. create dataElement in a dataElementGroup
2. outdate the dataElementGroup
3. Call the dataElement paths
4. The response array should contain two paths and not just one
